### PR TITLE
fix: allow some punctuation after inline katex

### DIFF
--- a/spec/__snapshots__/index.test.js.snap
+++ b/spec/__snapshots__/index.test.js.snap
@@ -114,15 +114,35 @@ exports[`marked-katex-extension inline katex with $ inside 1`] = `
 "
 `;
 
+exports[`marked-katex-extension inline katex with a colon after 1`] = `
+"<p>this is inline katex: <span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>x</mi></mrow><annotation encoding="application/x-tex">x</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.4306em;"></span><span class="mord mathnormal">x</span></span></span></span>:</p>
+"
+`;
+
+exports[`marked-katex-extension inline katex with a comma after 1`] = `
+"<p>this is inline katex: <span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>x</mi></mrow><annotation encoding="application/x-tex">x</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.4306em;"></span><span class="mord mathnormal">x</span></span></span></span>,</p>
+"
+`;
+
+exports[`marked-katex-extension inline katex with a period after 1`] = `
+"<p>this is inline katex: <span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>x</mi></mrow><annotation encoding="application/x-tex">x</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.4306em;"></span><span class="mord mathnormal">x</span></span></span></span>.</p>
+"
+`;
+
+exports[`marked-katex-extension inline katex with a question mark after 1`] = `
+"<p>this is inline katex: <span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>x</mi></mrow><annotation encoding="application/x-tex">x</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.4306em;"></span><span class="mord mathnormal">x</span></span></span></span>?</p>
+"
+`;
+
+exports[`marked-katex-extension inline katex with an exclamation mark after 1`] = `
+"<p>this is inline katex: <span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>x</mi></mrow><annotation encoding="application/x-tex">x</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.4306em;"></span><span class="mord mathnormal">x</span></span></span></span>!</p>
+"
+`;
+
 exports[`marked-katex-extension inline katex with newline 1`] = `
 "<p>this is not katex: $
 c = \\pm\\sqrt{a^2 + b^2}
 $</p>
-"
-`;
-
-exports[`marked-katex-extension inline katex with puncuation after 1`] = `
-"<p>this is inline katex: <span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>x</mi></mrow><annotation encoding="application/x-tex">x</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.4306em;"></span><span class="mord mathnormal">x</span></span></span></span>, <span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>O</mi><mo stretchy="false">(</mo><mi>l</mi><mi>o</mi><mi>g</mi><mo stretchy="false">(</mo><mi>n</mi><mo stretchy="false">)</mo><mo stretchy="false">)</mo></mrow><annotation encoding="application/x-tex">O(log(n))</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:1em;vertical-align:-0.25em;"></span><span class="mord mathnormal" style="margin-right:0.02778em;">O</span><span class="mopen">(</span><span class="mord mathnormal" style="margin-right:0.01968em;">l</span><span class="mord mathnormal">o</span><span class="mord mathnormal" style="margin-right:0.03588em;">g</span><span class="mopen">(</span><span class="mord mathnormal">n</span><span class="mclose">))</span></span></span></span>.</p>
 "
 `;
 

--- a/spec/__snapshots__/index.test.js.snap
+++ b/spec/__snapshots__/index.test.js.snap
@@ -121,6 +121,11 @@ $</p>
 "
 `;
 
+exports[`marked-katex-extension inline katex with puncuation after 1`] = `
+"<p>this is inline katex: <span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>x</mi></mrow><annotation encoding="application/x-tex">x</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.4306em;"></span><span class="mord mathnormal">x</span></span></span></span>, <span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>O</mi><mo stretchy="false">(</mo><mi>l</mi><mi>o</mi><mi>g</mi><mo stretchy="false">(</mo><mi>n</mi><mo stretchy="false">)</mo><mo stretchy="false">)</mo></mrow><annotation encoding="application/x-tex">O(log(n))</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:1em;vertical-align:-0.25em;"></span><span class="mord mathnormal" style="margin-right:0.02778em;">O</span><span class="mopen">(</span><span class="mord mathnormal" style="margin-right:0.01968em;">l</span><span class="mord mathnormal">o</span><span class="mord mathnormal" style="margin-right:0.03588em;">g</span><span class="mopen">(</span><span class="mord mathnormal">n</span><span class="mclose">))</span></span></span></span>.</p>
+"
+`;
+
 exports[`marked-katex-extension multiple block katex $ 1`] = `
 "<h1>pi:</h1>
 <span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>π</mi></mrow><annotation encoding="application/x-tex">\\pi</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.4306em;"></span><span class="mord mathnormal" style="margin-right:0.03588em;">π</span></span></span></span>

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -63,6 +63,7 @@ a$}
 $$
 `,
     'inline katex with $ inside': 'this is inline katex: $a\\raisebox{0.25em}{$b$}c$',
+    'inline katex with puncuation after': 'this is inline katex: $x$, $O(log(n))$.',
     'inline katex $$...$': 'this is not katex: $$a\\raisebox{0.25em}{$b$}c$',
     'inline katex $...$$': 'this is not katex: $a\\raisebox{0.25em}{$b$}c$$',
     'slash $': 'must include space between katex and end delimiter: $ \\$ $',

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -63,7 +63,11 @@ a$}
 $$
 `,
     'inline katex with $ inside': 'this is inline katex: $a\\raisebox{0.25em}{$b$}c$',
-    'inline katex with puncuation after': 'this is inline katex: $x$, $O(log(n))$.',
+    'inline katex with a question mark after': 'this is inline katex: $x$?',
+    'inline katex with an exclamation mark after': 'this is inline katex: $x$!',
+    'inline katex with a period after': 'this is inline katex: $x$.',
+    'inline katex with a comma after': 'this is inline katex: $x$,',
+    'inline katex with a colon after': 'this is inline katex: $x$:',
     'inline katex $$...$': 'this is not katex: $$a\\raisebox{0.25em}{$b$}c$',
     'inline katex $...$$': 'this is not katex: $a\\raisebox{0.25em}{$b$}c$$',
     'slash $': 'must include space between katex and end delimiter: $ \\$ $',

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import katex from 'katex';
 
 const inlineStartRule = /(?<=\s|^)\${1,2}(?!\$)/;
-const inlineRule = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])+?)(?<!\$)\1(?=[^\w}\$]|$)/;
+const inlineRule = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])+?)(?<!\$)\1(?=[\s?!\.,:]|$)/;
 const blockRule = /^(\${1,2})\n((?:\\[^]|[^\\])+?)\n\1(?:\n|$)/;
 
 export default function(options = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import katex from 'katex';
 
 const inlineStartRule = /(?<=\s|^)\${1,2}(?!\$)/;
-const inlineRule = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])+?)(?<!\$)\1(?=\s|$)/;
+const inlineRule = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])+?)(?<!\$)\1(?=[^\w}\$]|$)/;
 const blockRule = /^(\${1,2})\n((?:\\[^]|[^\\])+?)\n\1(?:\n|$)/;
 
 export default function(options = {}) {


### PR DESCRIPTION
This PR allows some punctuation to follow directly after the closing dollar sign for inline latex, similar to [autolink][autolink] rules. 

See issue #193

[autolink]: https://github.github.com/gfm/#extended-autolink-path-validation