### PR TITLE
fix: does not break a paragraph

### DIFF
--- a/spec/__snapshots__/index.test.js.snap
+++ b/spec/__snapshots__/index.test.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`marked-katex-extension $ in code fence not katex 1`] = `
+"<p>text on line before it</p>
+<pre><code>$ cat README
+Hello World!
+</code></pre>
+"
+`;
+
 exports[`marked-katex-extension block katex 1`] = `
 "<p>This is block level katex:</p>
 <span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>c</mi><mo>=</mo><mo>±</mo><msqrt><mrow><msup><mi>a</mi><mn>2</mn></msup><mo>+</mo><msup><mi>b</mi><mn>2</mn></msup></mrow></msqrt></mrow><annotation encoding="application/x-tex">c = \\pm\\sqrt{a^2 + b^2}</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.4306em;"></span><span class="mord mathnormal">c</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">=</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:1.24em;vertical-align:-0.1777em;"></span><span class="mord">±</span><span class="mord sqrt"><span class="vlist-t vlist-t2"><span class="vlist-r"><span class="vlist" style="height:1.0623em;"><span class="svg-align" style="top:-3.2em;"><span class="pstrut" style="height:3.2em;"></span><span class="mord" style="padding-left:1em;"><span class="mord"><span class="mord mathnormal">a</span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height:0.7401em;"><span style="top:-2.989em;margin-right:0.05em;"><span class="pstrut" style="height:2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight">2</span></span></span></span></span></span></span></span><span class="mspace" style="margin-right:0.2222em;"></span><span class="mbin">+</span><span class="mspace" style="margin-right:0.2222em;"></span><span class="mord"><span class="mord mathnormal">b</span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height:0.7401em;"><span style="top:-2.989em;margin-right:0.05em;"><span class="pstrut" style="height:2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight">2</span></span></span></span></span></span></span></span></span></span><span style="top:-3.0223em;"><span class="pstrut" style="height:3.2em;"></span><span class="hide-tail" style="min-width:1.02em;height:1.28em;"><svg xmlns="http://www.w3.org/2000/svg" width='400em' height='1.28em' viewBox='0 0 400000 1296' preserveAspectRatio='xMinYMin slice'><path d='M263,681c0.7,0,18,39.7,52,119
@@ -60,6 +68,15 @@ M1001 80h400000v40h-400000z'/></svg></span></span></span><span class="vlist-s">�
 exports[`marked-katex-extension block slash $ 1`] = `
 "<p>this is block katex:</p>
 <span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi mathvariant="normal">$</mi><mi mathvariant="normal">$</mi></mrow><annotation encoding="application/x-tex">\\$\\$</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.8056em;vertical-align:-0.0556em;"></span><span class="mord">$$</span></span></span></span></span>
+"
+`;
+
+exports[`marked-katex-extension does not break paragraph 1`] = `
+"<p>text on line before it
+$$
+This is not katex since there is no blank line above it.
+It is part of the previous paragraph.
+$$</p>
 "
 `;
 

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -114,6 +114,20 @@ $$
 $$
 \\theta
 $$
+`,
+    '$ in code fence not katex': `
+text on line before it
+\`\`\`
+$ cat README
+Hello World!
+\`\`\`
+`,
+    'does not break paragraph': `
+text on line before it
+$$
+This is not katex since there is no blank line above it.
+It is part of the previous paragraph.
+$$
 `
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,6 @@ function blockKatex(options, renderer) {
   return {
     name: 'blockKatex',
     level: 'block',
-    start(src) { return src.indexOf('\n$'); },
     tokenizer(src, tokens) {
       const match = src.match(blockRule);
       if (match) {


### PR DESCRIPTION
Require a blank line for block katex if previous token is a paragraph

fixes #250 