### PR TITLE
feat: support LaTeX syntax for math

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,17 @@
 import katex from 'katex';
 
-const inlineRule = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n\$]))\1(?=[\s?!\.,:？！。，：]|$)/;
+const inlineRule = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n$]))\1(?=[\s?!.,:？！。，：]|$)/;
 const blockRule = /^(\${1,2})\n((?:\\[^]|[^\\])+?)\n\1(?:\n|$)/;
+const alternativeInlineRule = /^\\\((?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n$]))\\\)(?=[\s?!.,:？！。，：]|$)/;
+const alternativeBlockRule = /^\\\[(\s*)((?:\\[^]|[^\\])+?)(\s*)\\](?:\n|$)/;
 
 export default function(options = {}) {
   return {
     extensions: [
       inlineKatex(options, createRenderer(options, false)),
-      blockKatex(options, createRenderer(options, true))
+      blockKatex(options, createRenderer(options, true)),
+      altInlineKatex(options, createRenderer(options, false)),
+      altBlockKatex(options, createRenderer(options, true))
     ]
   };
 }
@@ -41,7 +45,7 @@ function inlineKatex(options, renderer) {
         indexSrc = indexSrc.substring(index + 1).replace(/^\$+/, '');
       }
     },
-    tokenizer(src, tokens) {
+    tokenizer(src) {
       const match = src.match(inlineRule);
       if (match) {
         return {
@@ -60,7 +64,7 @@ function blockKatex(options, renderer) {
   return {
     name: 'blockKatex',
     level: 'block',
-    tokenizer(src, tokens) {
+    tokenizer(src) {
       const match = src.match(blockRule);
       if (match) {
         return {
@@ -68,6 +72,65 @@ function blockKatex(options, renderer) {
           raw: match[0],
           text: match[2].trim(),
           displayMode: match[1].length === 2
+        };
+      }
+    },
+    renderer
+  };
+}
+
+function altInlineKatex(options, renderer) {
+  return {
+    name: 'altInlineKatex',
+    level: 'inline',
+    start(src) {
+      let index;
+      let indexSrc = src;
+
+      while (indexSrc) {
+        index = indexSrc.indexOf('\\(');
+        if (index === -1) {
+          return;
+        }
+
+        if (index === 0 || indexSrc.charAt(index - 1) === ' ') {
+          const possibleKatex = indexSrc.substring(index + 1);
+
+          if (possibleKatex.match(alternativeInlineRule)) {
+            return index;
+          }
+        }
+
+        indexSrc = indexSrc.substring(index + 2).replace(/^\\[()]/, '');
+      }
+    },
+    tokenizer(src) {
+      const match = src.match(alternativeInlineRule);
+      if (match) {
+        return {
+          type: 'inlineKatex',
+          raw: match[0],
+          text: match[1].trim(),
+          displayMode: false
+        };
+      }
+    },
+    renderer
+  };
+}
+
+function altBlockKatex(options, renderer) {
+  return {
+    name: 'altBlockKatex',
+    level: 'block',
+    tokenizer(src) {
+      const match = src.match(alternativeBlockRule);
+      if (match) {
+        return {
+          type: 'blockKatex',
+          raw: match[0],
+          text: match[2].trim(),
+          displayMode: true
         };
       }
     },


### PR DESCRIPTION
Add support for using LaTeX syntax for math. This enables `\( \)` to be used for inline math and `\[ \]` to be used for block-level math. Closes #280.

Caveat: the implementation now would only try to match the shortest backtick-parenthesis pair, meaning `\( one \( two \) one \)` is parsed as `\( one \( two \)` and a stray `one \)`. In LaTeX, nesting is not allowed and is reported as an error, but it is not implemented yet.