### PR TITLE
fix: move katex to a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ You will still need to include the css in your html document to allow katex styl
 import {marked} from "marked";
 import markedKatex from "marked-katex-extension";
 
-// or UMD script
-// <script src="https://cdn.jsdelivr.net/npm/marked/lib/marked.umd.js"></script>
-// <script src="https://cdn.jsdelivr.net/npm/marked-katex-extension/lib/index.umd.js"></script>
+// or in the browser
+// <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@{version}/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">
+// <script defer src="https://cdn.jsdelivr.net/npm/katex@{version}/dist/katex.min.js" integrity="sha384-XjKyOOlGwcjNTAIQHIpgOno0Hl1YQqzUOEleOLALmuqehneUG+vnGctmUb0ZY0l8" crossorigin="anonymous"></script>
+// <script src="https://cdn.jsdelivr.net/npm/marked@{version}/lib/marked.umd.js"></script>
+// <script src="https://cdn.jsdelivr.net/npm/marked-katex-extension@{version}/lib/index.umd.js"></script>
 
 const options = {
   throwOnError: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "4.0.5",
       "license": "MIT",
       "dependencies": {
-        "@types/katex": "^0.16.7",
-        "katex": "^0.16.9"
+        "@types/katex": "^0.16.7"
       },
       "devDependencies": {
         "@babel/core": "^7.23.7",
@@ -31,6 +30,7 @@
         "eslint-plugin-n": "^16.6.0",
         "eslint-plugin-promise": "^6.1.1",
         "jest-cli": "^29.7.0",
+        "katex": "^0.16.9",
         "marked": "^11.1.1",
         "node-fetch": "^3.3.2",
         "rollup": "^4.9.2",
@@ -38,6 +38,7 @@
         "tsd": "^0.30.1"
       },
       "peerDependencies": {
+        "katex": ">=0.16 <0.17",
         "marked": ">=4 <12"
       }
     },
@@ -4874,6 +4875,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
       "engines": {
         "node": ">= 12"
       }
@@ -8214,6 +8216,7 @@
       "version": "0.16.9",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.9.tgz",
       "integrity": "sha512-fsSYjWS0EEOwvy81j3vRA8TEAhQhKiqO+FQaKWp0m39qwOzHVBgAUBIXWj1pB+O2W3fIpNa6Y9KSKCVbfPhyAQ==",
+      "dev": true,
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -18313,7 +18316,8 @@
     "commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true
     },
     "compare-func": {
       "version": "2.0.0",
@@ -20740,6 +20744,7 @@
       "version": "0.16.9",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.9.tgz",
       "integrity": "sha512-fsSYjWS0EEOwvy81j3vRA8TEAhQhKiqO+FQaKWp0m39qwOzHVBgAUBIXWj1pB+O2W3fIpNa6Y9KSKCVbfPhyAQ==",
+      "dev": true,
       "requires": {
         "commander": "^8.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   },
   "homepage": "https://github.com/UziTech/marked-katex-extension#readme",
   "peerDependencies": {
-    "marked": ">=4 <12"
+    "marked": ">=4 <12",
+    "katex": ">=0.16 <0.17"
   },
   "devDependencies": {
     "@babel/core": "^7.23.7",
@@ -64,6 +65,7 @@
     "eslint-plugin-n": "^16.6.0",
     "eslint-plugin-promise": "^6.1.1",
     "jest-cli": "^29.7.0",
+    "katex": "^0.16.9",
     "marked": "^11.1.1",
     "node-fetch": "^3.3.2",
     "rollup": "^4.9.2",
@@ -71,7 +73,6 @@
     "tsd": "^0.30.1"
   },
   "dependencies": {
-    "@types/katex": "^0.16.7",
-    "katex": "^0.16.9"
+    "@types/katex": "^0.16.7"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,11 +8,12 @@ export default [
       file: 'lib/index.umd.js',
       format: 'umd',
       globals: {
-        marked: 'marked'
+        marked: 'marked',
+        katex: 'katex'
       }
     },
     plugins: [nodeResolve()],
-    external: ['marked']
+    external: ['marked', 'katex']
   },
   {
     input: 'src/index.js',


### PR DESCRIPTION
BREAKING CHANGE: katex will need to be added as a dependency along with this extension

fixes #315 