### PR TITLE
fix: Fix export types

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "test": "npm run build && npm run test:cover && npm run test:spec && npm run test:types && npm run lint",
+    "test": "npm run build && npm run test:cover && npm run test:spec && npm run test:types && npm run test:exports && npm run lint",
+    "test:exports": "cd spec/exports && npm install && npx tsc",
     "test:katex": "jest --verbose",
     "test:spec": "node --test spec/marked-tests.js",
     "test:cover": "jest --coverage",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./src/index.d.ts",
       "import": "./src/index.js",
       "require": "./lib/index.cjs"
     },

--- a/spec/exports/index.mts
+++ b/spec/exports/index.mts
@@ -1,0 +1,4 @@
+import katex from 'marked-katex-extension';
+import type { MarkedExtension } from 'marked';
+
+katex({}) satisfies MarkedExtension;

--- a/spec/exports/package-lock.json
+++ b/spec/exports/package-lock.json
@@ -1,0 +1,47 @@
+{
+  "name": "exports",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "marked-katex-extension": "file:../.."
+      }
+    },
+    "../..": {
+      "version": "5.1.9",
+      "license": "MIT",
+      "devDependencies": {
+        "@babel/core": "^7.29.7",
+        "@babel/preset-env": "^7.29.7",
+        "@markedjs/eslint-config": "^1.0.14",
+        "@markedjs/testutils": "18.0.0-1",
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "@semantic-release/changelog": "^6.0.3",
+        "@semantic-release/commit-analyzer": "^13.0.1",
+        "@semantic-release/git": "^10.0.1",
+        "@semantic-release/github": "^12.0.8",
+        "@semantic-release/npm": "^13.1.5",
+        "@semantic-release/release-notes-generator": "^14.1.1",
+        "babel-jest": "^30.3.0",
+        "cheerio": "^1.2.0",
+        "globals": "^17.6.0",
+        "jest-cli": "^30.4.2",
+        "katex": "^0.17.0",
+        "marked": "^18.0.4",
+        "node-fetch": "^3.3.2",
+        "rollup": "^4.60.4",
+        "semantic-release": "^25.0.3",
+        "tsd": "^0.33.0"
+      },
+      "peerDependencies": {
+        "katex": ">=0.16 <0.18",
+        "marked": ">=4 <19"
+      }
+    },
+    "node_modules/marked-katex-extension": {
+      "resolved": "../..",
+      "link": true
+    }
+  }
+}

--- a/spec/exports/package.json
+++ b/spec/exports/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "dependencies": {
+    "marked-katex-extension": "file:../.."
+  },
+  "type": "commonjs"
+}

--- a/spec/exports/tsconfig.json
+++ b/spec/exports/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+  }
+}


### PR DESCRIPTION
This PR add a `types` package.json export condition, fixing #692.

There are 2 separate commit:
1. The actual one-line fix: f3aa086eaa9e41e5ce72134ac2ad137dc3ac79f4
2. An extra commit 150aaa4d668833689a858123d89d062cc8b461ca which sets up a dummy dependent package and test for regression.

Please feel free to discard commit 150aaa4d668833689a858123d89d062cc8b461ca as it might be overkill, it just made things easier for me to confirm the fix worked.

Also, I noticed that the bug only happened in a specific context: when using an ESM TS file within a `"type": "commonjs"` package, so it is an actual but relatively narrow problem (which in my case happened in a NestJS project).