### PR TITLE
fix: allow KaTeX 0.18 as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "typescript": "^6.0.3"
       },
       "peerDependencies": {
-        "katex": "^0.18.4",
+        "katex": ">=0.16 <0.19",
         "marked": ">=4 <19"
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/UziTech/marked-katex-extension#readme",
   "peerDependencies": {
-    "katex": ">=0.16 <0.18",
+    "katex": ">=0.16 <0.19",
     "marked": ">=4 <19"
   },
   "devDependencies": {


### PR DESCRIPTION
In #714, the KaTeX version bounds were updated to include KaTeX 0.18 only for dev dependencies. Hence `package-lock.json` already pins 0.18.1 as the KaTeX version and tests pass with that version.

However, the peer dependency bounds don't allow KaTeX 0.18 yet, so projects that attempt to install this package along with KaTeX 0.18 run into issues. This PR updates the peer dependency bounds to allow KaTeX 0.18.